### PR TITLE
Flash Attention

### DIFF
--- a/pytorch_widedeep/models/tabular/transformers/_attention_layers.py
+++ b/pytorch_widedeep/models/tabular/transformers/_attention_layers.py
@@ -73,6 +73,9 @@ class MultiHeadedAttention(nn.Module):
         super(MultiHeadedAttention, self).__init__()
 
         self.flash = use_flash
+        if self.flash:
+            assert hasattr(F, 'scaled_dot_product_attention')
+    
         self.drop_pc = dropout
 
         assert input_dim % n_heads == 0, "'input_dim' must be divisible by 'n_heads'"

--- a/tests/test_model_components/test_mc_attention_layer.py
+++ b/tests/test_model_components/test_mc_attention_layer.py
@@ -1,0 +1,36 @@
+import torch
+import timeit
+
+from pytorch_widedeep.models.tabular.transformers._attention_layers import MultiHeadedAttention
+
+input_dim = 128
+n_heads = 4
+
+m = MultiHeadedAttention(
+    input_dim=input_dim,
+    n_heads=n_heads,
+    use_bias=False,
+    dropout=0.2
+)
+
+mf = MultiHeadedAttention(
+    input_dim=input_dim,
+    n_heads=n_heads,
+    use_bias=False,
+    dropout=0.2,
+    use_flash=True
+)
+
+X = torch.randn(32, 10, input_dim)
+
+def test_flash_standard_shapes():
+    # Check that shapes of output are the same
+    assert m(X).shape == mf(X).shape
+
+def test_speedup_flash():
+    # Check that iterations happen faster
+    standard_its = timeit.timeit(lambda: m(X), number=3000)
+    flash_its = timeit.timeit(lambda: mf(X), number=3000)
+
+    assert standard_its > flash_its
+    assert ((standard_its - flash_its) / standard_its) > 0.1


### PR DESCRIPTION
* Add option to use flash attention in MultiHeadAttention (raises attribute error if pytorch not 2.0)
* Torch flash attention from scaled_dot_product_attention - output from heads concatenated using einops.
* Benchmark tests for checking that the flash implementation is on average faster (by at least 10%).