### PR TITLE
Self_training_fix

### DIFF
--- a/pytorch_widedeep/losses.py
+++ b/pytorch_widedeep/losses.py
@@ -959,7 +959,7 @@ class EncoderDecoderLoss(nn.Module):
         x_true_means[x_true_means == 0] = 1
 
         x_true_stds = torch.std(x_true, dim=0) ** 2
-        x_true_stds[x_true_stds == 0] = x_true_means[x_true_stds == 0]
+        x_true_stds[x_true_stds == 0] = torch.abs(x_true_means[x_true_stds == 0])
 
         features_loss = torch.matmul(reconstruction_errors, 1 / x_true_stds)
         nb_reconstructed_variables = torch.sum(mask, dim=1)

--- a/pytorch_widedeep/models/tabular/self_supervised/encoder_decoder_model.py
+++ b/pytorch_widedeep/models/tabular/self_supervised/encoder_decoder_model.py
@@ -82,7 +82,7 @@ class EncoderDecoderModel(nn.Module):
             x_embed_rec = self.decoder(steps_out)
             mask = torch.ones(x_embed.shape).to(X.device)
 
-        return x_embed_rec, x_embed, mask
+        return x_embed, x_embed_rec, mask
 
     def _build_decoder(self, encoder: ModelWithoutAttention) -> DecoderWithoutAttention:
         if isinstance(encoder, TabMlp):


### PR DESCRIPTION
# Fix bugs in EncoderDecoderTrainer and EncoderDecoderLoss

I identified two bugs while using EncoderDecoderTrainer for pretraining:

### Issue 1: Negative Loss Values in EncoderDecoderLoss

When calculating the loss, if `x_true_stds` is zero, it's replaced with the corresponding value from `x_true_means`. If these mean values are negative, they cause the loss to become negative, which is problematic for optimization.

The problematic code:

```python
x_true_stds = torch.std(x_true, dim=0) ** 2
x_true_stds[x_true_stds == 0] = x_true_means[x_true_stds == 0]
```


### Issue 2: Inconsistent Return Order in _forward_tabnet

The `_forward_tabnet` method returns values in a different order compared to other encoder-decoder models:

- Other models: `x_embed, x_embed_rec, mask`
- TabNet: `x_embed_rec, x_embed, mask`

This inconsistency causes incorrect inputs to the loss function when using TabNet with EncoderDecoderTrainer.

## Solution

### For Issue 1:

Modified the EncoderDecoderLoss to use the absolute value of means when replacing zero standard deviations:

```python
x_true_stds[x_true_stds == 0] = torch.abs(x_true_means[x_true_stds == 0])
```

This ensures that the scaling factor remains positive, which is conceptually correct since standard deviations are always non-negative.

### For Issue 2:

Changed the return order in `_forward_tabnet` to match the convention used by other models:

```python
return x_embed, x_embed_rec, mask  # Previously: x_embed_rec, x_embed, mask
```