### PR TITLE
Added Support for multiple GPUs

### DIFF
--- a/pytorch_widedeep/models/wide_deep.py
+++ b/pytorch_widedeep/models/wide_deep.py
@@ -297,9 +297,13 @@ class WideDeep(nn.Module):
             first_model_mode = list(X.keys())[0]
             if isinstance(X[first_model_mode], list):
                 batch_size = X[first_model_mode][0].size(0)
+                # Get device from input tensor
+                device = X[first_model_mode][0].device
             else:
                 batch_size = X[first_model_mode].size(0)  # type: ignore[union-attr]
-            out = torch.zeros(batch_size, self.pred_dim).to(self.wd_device)
+                # Get device from input tensor
+                device = X[first_model_mode].device  # type: ignore[union-attr]
+            out = torch.zeros(batch_size, self.pred_dim, device=device)
 
         return out
 
@@ -331,7 +335,9 @@ class WideDeep(nn.Module):
     def _forward_deephead(
         self, X: Dict[str, Union[Tensor, List[Tensor]]], wide_out: Tensor
     ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
-        deepside = torch.FloatTensor().to(self.wd_device)
+        # Get device from wide_out
+        device = wide_out.device
+        deepside = torch.FloatTensor().to(device)
 
         if self.deeptabular is not None:
             if self.is_tabnet:

--- a/pytorch_widedeep/training/_base_trainer.py
+++ b/pytorch_widedeep/training/_base_trainer.py
@@ -78,9 +78,21 @@ class BaseTrainer(ABC):
         self.seed = seed
 
         self.model = to_device_model(model, self.device)
-        if self.model.is_tabnet:
+
+        self.is_model_tabnet = model.is_tabnet
+        if self.is_model_tabnet:
             self.lambda_sparse = kwargs.get("lambda_sparse", 1e-3)
+
+        # Simply we need this attribute
         self.model.wd_device = self.device
+
+        use_multi_gpu = kwargs.get("use_multi_gpu", False) and self.device.startswith(
+            "cuda"
+        )
+        if use_multi_gpu and torch.cuda.device_count() > 1:
+            if self.verbose:
+                print(f"Using {torch.cuda.device_count()} GPUs for training")
+            self.model = torch.nn.DataParallel(self.model)
 
         self.objective = objective
         self.method: str = _ObjectiveToMethod.get(objective)  # type: ignore
@@ -444,6 +456,14 @@ class BaseTrainer(ABC):
         num_workers = kwargs.get("num_workers", default_num_workers)
         default_device = setup_device()
         device = kwargs.get("device", default_device)
+
+        # Check for multi-GPU setup
+        use_cuda = device.startswith("cuda")
+        use_multi_gpu = use_cuda and kwargs.get("use_multi_gpu", False)
+
+        if use_multi_gpu and torch.cuda.device_count() > 1:
+            device = f"cuda:{torch.cuda.current_device()}"
+
         return device, num_workers
 
     def __repr__(self) -> str:  # noqa: C901

--- a/pytorch_widedeep/training/trainer.py
+++ b/pytorch_widedeep/training/trainer.py
@@ -834,22 +834,37 @@ class Trainer(BaseTrainer):
         r"""
         Simple wrap-up to individually fine-tune model components
         """
-        if self.model.deephead is not None:
+
+        # if the model is a DataParallel, we need to get the model
+        # from the first device
+        if isinstance(self.model, torch.nn.DataParallel):
+            if self.verbose:
+                print(
+                    "DataParallel model. Note that each extracted component will be a"
+                    " regular PyTorch module running on a single GPU. Once the"
+                    " finetuning is done, the model will be returned to the original"
+                    " DataParallel model."
+                )
+            model_ = self.model.module
+        else:
+            model_ = self.model
+
+        if model_.deephead is not None:
             raise ValueError(
                 "Currently warming up is only supported without a fully connected 'DeepHead'"
             )
 
         finetuner = FineTune(self.loss_fn, self.metric, self.method, self.verbose)  # type: ignore[arg-type]
-        if self.model.wide:
-            finetuner.finetune_all(self.model.wide, "wide", loader, n_epochs, max_lr)
+        if model_.wide:
+            finetuner.finetune_all(model_.wide, "wide", loader, n_epochs, max_lr)
 
-        if self.model.deeptabular:
+        if model_.deeptabular:
             if deeptabular_gradual:
                 assert (
                     deeptabular_layers is not None
                 ), "deeptabular_layers must be passed if deeptabular_gradual=True"
                 finetuner.finetune_gradual(
-                    self.model.deeptabular,
+                    model_.deeptabular,
                     "deeptabular",
                     loader,
                     deeptabular_max_lr,
@@ -858,16 +873,16 @@ class Trainer(BaseTrainer):
                 )
             else:
                 finetuner.finetune_all(
-                    self.model.deeptabular, "deeptabular", loader, n_epochs, max_lr
+                    model_.deeptabular, "deeptabular", loader, n_epochs, max_lr
                 )
 
-        if self.model.deeptext:
+        if model_.deeptext:
             if deeptext_gradual:
                 assert (
                     deeptext_layers is not None
                 ), "deeptext_layers must be passed if deeptext_gradual=True"
                 finetuner.finetune_gradual(
-                    self.model.deeptext,
+                    model_.deeptext,
                     "deeptext",
                     loader,
                     deeptext_max_lr,
@@ -876,16 +891,16 @@ class Trainer(BaseTrainer):
                 )
             else:
                 finetuner.finetune_all(
-                    self.model.deeptext, "deeptext", loader, n_epochs, max_lr
+                    model_.deeptext, "deeptext", loader, n_epochs, max_lr
                 )
 
-        if self.model.deepimage:
+        if model_.deepimage:
             if deepimage_gradual:
                 assert (
                     deepimage_layers is not None
                 ), "deepimage_layers must be passed if deepimage_gradual=True"
                 finetuner.finetune_gradual(
-                    self.model.deepimage,
+                    model_.deepimage,
                     "deepimage",
                     loader,
                     deepimage_max_lr,
@@ -894,7 +909,7 @@ class Trainer(BaseTrainer):
                 )
             else:
                 finetuner.finetune_all(
-                    self.model.deepimage, "deepimage", loader, n_epochs, max_lr
+                    model_.deepimage, "deepimage", loader, n_epochs, max_lr
                 )
 
     def _train_epoch(
@@ -944,7 +959,7 @@ class Trainer(BaseTrainer):
 
         y_pred = self.model(X)
 
-        if self.model.is_tabnet:
+        if self.is_model_tabnet:
             loss = self.loss_fn(y_pred[0], y) - self.lambda_sparse * y_pred[1]
             score = self._get_score(y_pred[0], y, is_train=True)
         else:
@@ -1008,7 +1023,7 @@ class Trainer(BaseTrainer):
             y = to_device(y, self.device)
 
             y_pred = self.model(X)
-            if self.model.is_tabnet:
+            if self.is_model_tabnet:
                 loss = self.loss_fn(y_pred[0], y) - self.lambda_sparse * y_pred[1]
                 score = self._get_score(y_pred[0], y, is_train=False)
             else:
@@ -1119,7 +1134,7 @@ class Trainer(BaseTrainer):
                                     X[k] = to_device(v, self.device)
                             preds = (
                                 self.model(X)
-                                if not self.model.is_tabnet
+                                if not self.is_model_tabnet
                                 else self.model(X)[0]
                             )
                             if self.method == "binary":
@@ -1170,6 +1185,7 @@ class Trainer(BaseTrainer):
             "prefetch_factor",
             "persistent_workers",
             "oversample_mul",
+            "pin_memory",
         ]
         finetune_params = [
             "n_epochs",

--- a/pytorch_widedeep/training/trainer.py
+++ b/pytorch_widedeep/training/trainer.py
@@ -160,12 +160,21 @@ class Trainer(BaseTrainer):
         - **num_workers**: `int`<br/>
             number of workers to be used internally by the data loaders
 
+        - **use_multi_gpu**: `bool`<br/>
+            If True, the model will be trained on multiple GPUs. This is
+            only supported for the `deeptabular` component.
+
+            NOTE: this is an experimental feature and might not work as expected
+            in some cases. In the particular case of the `Trainer` class, it has
+            been extensively tested.
+
         - **lambda_sparse**: `float`<br/>
             lambda sparse parameter in case the `deeptabular` component is `TabNet`
 
         - **class_weight**: `List[float]`<br/>
             This is the `weight` or `pos_weight` parameter in
             `CrossEntropyLoss` and `BCEWithLogitsLoss`, depending on whether
+
         - **reducelronplateau_criterion**: `str`
             This sets the criterion that will be used by the lr scheduler to
             take a step: One of _'loss'_ or _'metric'_. The ReduceLROnPlateau
@@ -835,36 +844,57 @@ class Trainer(BaseTrainer):
         Simple wrap-up to individually fine-tune model components
         """
 
-        # if the model is a DataParallel, we need to get the model
-        # from the first device
         if isinstance(self.model, torch.nn.DataParallel):
-            if self.verbose:
-                print(
-                    "DataParallel model. Note that each extracted component will be a"
-                    " regular PyTorch module running on a single GPU. Once the"
-                    " finetuning is done, the model will be returned to the original"
-                    " DataParallel model."
-                )
-            model_ = self.model.module
+            wide_component = (
+                torch.nn.DataParallel(self.model.module.wide)
+                if self.model.module.wide
+                else None
+            )
+            deeptabular_component = (
+                torch.nn.DataParallel(self.model.module.deeptabular)
+                if self.model.module.deeptabular
+                else None
+            )
+            deeptext_component = (
+                torch.nn.DataParallel(self.model.module.deeptext)
+                if self.model.module.deeptext
+                else None
+            )
+            deepimage_component = (
+                torch.nn.DataParallel(self.model.module.deepimage)
+                if self.model.module.deepimage
+                else None
+            )
+            deephead_component = (
+                torch.nn.DataParallel(self.model.module.deephead)
+                if self.model.module.deephead
+                else None
+            )
         else:
-            model_ = self.model
+            wide_component = self.model.wide if self.model.wide else None
+            deeptabular_component = (
+                self.model.deeptabular if self.model.deeptabular else None
+            )
+            deeptext_component = self.model.deeptext if self.model.deeptext else None
+            deepimage_component = self.model.deepimage if self.model.deepimage else None
+            deephead_component = self.model.deephead if self.model.deephead else None
 
-        if model_.deephead is not None:
+        if deephead_component is not None:
             raise ValueError(
                 "Currently warming up is only supported without a fully connected 'DeepHead'"
             )
 
         finetuner = FineTune(self.loss_fn, self.metric, self.method, self.verbose)  # type: ignore[arg-type]
-        if model_.wide:
-            finetuner.finetune_all(model_.wide, "wide", loader, n_epochs, max_lr)
+        if wide_component:
+            finetuner.finetune_all(wide_component, "wide", loader, n_epochs, max_lr)
 
-        if model_.deeptabular:
+        if deeptabular_component:
             if deeptabular_gradual:
                 assert (
                     deeptabular_layers is not None
                 ), "deeptabular_layers must be passed if deeptabular_gradual=True"
                 finetuner.finetune_gradual(
-                    model_.deeptabular,
+                    deeptabular_component,
                     "deeptabular",
                     loader,
                     deeptabular_max_lr,
@@ -873,16 +903,16 @@ class Trainer(BaseTrainer):
                 )
             else:
                 finetuner.finetune_all(
-                    model_.deeptabular, "deeptabular", loader, n_epochs, max_lr
+                    deeptabular_component, "deeptabular", loader, n_epochs, max_lr
                 )
 
-        if model_.deeptext:
+        if deeptext_component:
             if deeptext_gradual:
                 assert (
                     deeptext_layers is not None
                 ), "deeptext_layers must be passed if deeptext_gradual=True"
                 finetuner.finetune_gradual(
-                    model_.deeptext,
+                    deeptext_component,
                     "deeptext",
                     loader,
                     deeptext_max_lr,
@@ -891,16 +921,16 @@ class Trainer(BaseTrainer):
                 )
             else:
                 finetuner.finetune_all(
-                    model_.deeptext, "deeptext", loader, n_epochs, max_lr
+                    deeptext_component, "deeptext", loader, n_epochs, max_lr
                 )
 
-        if model_.deepimage:
+        if deepimage_component:
             if deepimage_gradual:
                 assert (
                     deepimage_layers is not None
                 ), "deepimage_layers must be passed if deepimage_gradual=True"
                 finetuner.finetune_gradual(
-                    model_.deepimage,
+                    deepimage_component,
                     "deepimage",
                     loader,
                     deepimage_max_lr,
@@ -909,7 +939,7 @@ class Trainer(BaseTrainer):
                 )
             else:
                 finetuner.finetune_all(
-                    model_.deepimage, "deepimage", loader, n_epochs, max_lr
+                    deepimage_component, "deepimage", loader, n_epochs, max_lr
                 )
 
     def _train_epoch(

--- a/pytorch_widedeep/training/trainer_from_folder.py
+++ b/pytorch_widedeep/training/trainer_from_folder.py
@@ -144,7 +144,17 @@ class TrainerFromFolder(Trainer):
          - **num_workers**: `int`<br/>
              number of workers to be used internally by the data loaders
 
-         - **lambda_sparse**: `float`<br/>
+        - **use_multi_gpu**: `bool`<br/>
+            If True, the model will be trained on multiple GPUs. This is
+            only supported for the `deeptabular` component.
+
+            NOTE: this is an experimental feature and might not work as expected
+            in some cases. While for the `Trainer` class, it has been extensively
+            tested, for the `TrainerFromFolder` class, it has not been tested
+            that thoroughly (in principle the `TrainerFromFolder` inherits from
+            the `Trainer` class, so it should work).
+
+        - **lambda_sparse**: `float`<br/>
              lambda sparse parameter in case the `deeptabular` component is `TabNet`
 
          - **class_weight**: `List[float]`<br/>

--- a/pytorch_widedeep/utils/general_utils.py
+++ b/pytorch_widedeep/utils/general_utils.py
@@ -24,11 +24,10 @@ def to_device_model(model, device: str):  # noqa: C901
     # insistent transformation since it some cases overall approaches such as
     # model.to('mps') do not work
 
-    if device in ["cpu", f"cuda:{torch.cuda.current_device()}"]:
+    if device == "cpu" or (device.startswith("cuda") and torch.cuda.is_available()):
         return model.to(device)
 
     if device == "mps":
-
         try:
             return model.to(device)
         except (RuntimeError, TypeError):

--- a/pytorch_widedeep/utils/general_utils.py
+++ b/pytorch_widedeep/utils/general_utils.py
@@ -6,7 +6,7 @@ from torch import Tensor
 
 def setup_device() -> str:
     if torch.cuda.is_available():
-        return "cuda"
+        return f"cuda:{torch.cuda.current_device()}"
     elif torch.backends.mps.is_available():
         return "mps"
     else:
@@ -24,7 +24,7 @@ def to_device_model(model, device: str):  # noqa: C901
     # insistent transformation since it some cases overall approaches such as
     # model.to('mps') do not work
 
-    if device in ["cpu", "cuda"]:
+    if device in ["cpu", f"cuda:{torch.cuda.current_device()}"]:
         return model.to(device)
 
     if device == "mps":

--- a/tests/test_model_functioning/test_multi_gpu.py
+++ b/tests/test_model_functioning/test_multi_gpu.py
@@ -1,0 +1,190 @@
+import string
+
+import numpy as np
+import torch
+import pytest
+from torch import nn
+from torchvision.transforms import ToTensor, Normalize
+
+from pytorch_widedeep.models import Wide, TabMlp, Vision, BasicRNN, WideDeep
+from pytorch_widedeep.training import Trainer
+
+# Check if multiple GPUs are available
+multi_gpu_available = torch.cuda.is_available() and torch.cuda.device_count() > 1
+
+# Set random seed for reproducibility
+np.random.seed(42)
+
+# Create small matrices (500 observations)
+n_obs = 500
+
+# Wide array
+X_wide = np.random.choice(50, (n_obs, 10))
+
+# Deep Array (Tabular)
+colnames = list(string.ascii_lowercase)[:10]
+embed_cols = [np.random.choice(np.arange(5), n_obs) for _ in range(5)]
+embed_input = [(u, i, j) for u, i, j in zip(colnames[:5], [5] * 5, [16] * 5)]
+cont_cols = [np.random.rand(n_obs) for _ in range(5)]
+column_idx = {k: v for v, k in enumerate(colnames)}
+X_tab = np.vstack(embed_cols + cont_cols).transpose()
+
+# Text Array
+padded_sequences = np.random.choice(np.arange(1, 100), (n_obs, 48))
+X_text = np.hstack((np.repeat(np.array([[0, 0]]), n_obs, axis=0), padded_sequences))
+vocab_size = 110
+
+# Image Array
+X_img = np.random.choice(256, (n_obs, 224, 224, 3))
+X_img_norm = X_img / 255.0
+
+# Target
+target = np.random.choice(2, n_obs)
+
+
+@pytest.fixture
+def model_components():
+    # Wide component
+    wide = Wide(np.unique(X_wide).shape[0], 1)
+
+    # Tabular component
+    deeptabular = TabMlp(
+        column_idx=column_idx,
+        cat_embed_input=embed_input,
+        continuous_cols=colnames[-5:],
+        mlp_hidden_dims=[32, 16],
+        mlp_dropout=[0.5, 0.5],
+    )
+
+    # Text component
+    deeptext = BasicRNN(vocab_size=vocab_size, embed_dim=32, padding_idx=0)
+
+    # Image component
+    deepimage = Vision(pretrained_model_setup="resnet18", n_trainable=0)
+
+    return wide, deeptabular, deeptext, deepimage
+
+
+@pytest.mark.skipif(not multi_gpu_available, reason="Multiple GPUs not available")
+def test_multi_gpu_all_components(model_components):
+    wide, deeptabular, deeptext, deepimage = model_components
+
+    model = WideDeep(
+        wide=wide, deeptabular=deeptabular, deeptext=deeptext, deepimage=deepimage
+    )
+
+    trainer = Trainer(model, objective="binary", verbose=0, use_multi_gpu=True)
+
+    trainer.fit(
+        X_wide=X_wide,
+        X_tab=X_tab,
+        X_text=X_text,
+        X_img=X_img,
+        target=target,
+        batch_size=32,
+        n_epochs=1,
+    )
+
+    assert trainer.history["train_loss"] is not None
+
+
+@pytest.mark.skipif(not multi_gpu_available, reason="Multiple GPUs not available")
+def test_multi_gpu_deeptabular_only(model_components):
+    _, deeptabular, _, _ = model_components
+
+    model = WideDeep(deeptabular=deeptabular)
+
+    trainer = Trainer(model, objective="binary", verbose=0, use_multi_gpu=True)
+
+    trainer.fit(X_tab=X_tab, target=target, batch_size=32, n_epochs=1)
+
+    assert trainer.history["train_loss"] is not None
+
+
+@pytest.mark.skipif(not multi_gpu_available, reason="Multiple GPUs not available")
+def test_multi_gpu_with_deephead(model_components):
+    _, deeptabular, deeptext, deepimage = model_components
+
+    # Create a deephead
+    deephead = nn.Sequential(nn.Linear(592, 128), nn.ReLU(), nn.Linear(128, 64))
+    deephead.output_dim = 64
+
+    model = WideDeep(
+        deeptabular=deeptabular,
+        deeptext=deeptext,
+        deepimage=deepimage,
+        deephead=deephead,
+    )
+
+    trainer = Trainer(model, objective="binary", verbose=0, use_multi_gpu=True)
+
+    trainer.fit(
+        X_tab=X_tab,
+        X_text=X_text,
+        X_img=X_img,
+        target=target,
+        batch_size=32,
+        n_epochs=1,
+    )
+
+    assert trainer.history["train_loss"] is not None
+
+
+@pytest.mark.skipif(not multi_gpu_available, reason="Multiple GPUs not available")
+def test_multi_gpu_with_transforms(model_components):
+    _, deeptabular, _, deepimage = model_components
+
+    # Define transforms
+    mean = [0.406, 0.456, 0.485]  # BGR
+    std = [0.225, 0.224, 0.229]  # BGR
+    transforms = [ToTensor(), Normalize(mean=mean, std=std)]
+
+    model = WideDeep(deeptabular=deeptabular, deepimage=deepimage)
+
+    trainer = Trainer(
+        model, objective="binary", transforms=transforms, verbose=0, use_multi_gpu=True
+    )
+
+    trainer.fit(X_tab=X_tab, X_img=X_img, target=target, batch_size=32, n_epochs=1)
+
+    assert trainer.history["train_loss"] is not None
+
+
+@pytest.mark.skipif(not multi_gpu_available, reason="Multiple GPUs not available")
+def test_multi_gpu_with_finetune(model_components):
+    _, deeptabular, _, _ = model_components
+
+    model = WideDeep(deeptabular=deeptabular)
+
+    trainer = Trainer(model, objective="binary", verbose=0, use_multi_gpu=True)
+
+    trainer.fit(
+        X_tab=X_tab,
+        target=target,
+        batch_size=32,
+        n_epochs=1,
+        finetune=True,
+        finetune_epochs=1,
+    )
+
+    assert trainer.history["train_loss"] is not None
+    assert hasattr(trainer, "with_finetuning")
+    assert trainer.with_finetuning is True
+
+
+@pytest.mark.skipif(not multi_gpu_available, reason="Multiple GPUs not available")
+def test_multi_gpu_predict(model_components):
+    _, deeptabular, _, _ = model_components
+
+    model = WideDeep(deeptabular=deeptabular)
+
+    trainer = Trainer(model, objective="binary", verbose=0, use_multi_gpu=True)
+
+    trainer.fit(X_tab=X_tab, target=target, batch_size=32, n_epochs=1)
+
+    preds = trainer.predict(X_tab=X_tab, batch_size=32)
+    assert preds.shape[0] == n_obs
+
+    probs = trainer.predict_proba(X_tab=X_tab, batch_size=32)
+    assert probs.shape[0] == n_obs
+    assert probs.shape[1] == 2


### PR DESCRIPTION
This PR adds support for multiple GPUs via `nn.DataParallel` 

Simply, instantiate the `Trainer` with the param `use_multi_gpu` set to True and it will internally use all visible GPUs